### PR TITLE
Add a default style for blockquotes

### DIFF
--- a/src/core/_core-partials.scss
+++ b/src/core/_core-partials.scss
@@ -14,6 +14,7 @@
 @import 'partials/base/reset';
 @import 'partials/base/main';
 
+@import 'partials/base/blockquote';
 @import 'partials/base/code';
 @import 'partials/base/form';
 @import 'partials/base/fonts';

--- a/src/core/partials/base/_blockquote.scss
+++ b/src/core/partials/base/_blockquote.scss
@@ -1,0 +1,13 @@
+// # Blockquotes
+// For quoting blocks of content.
+
+// <div class="example html">
+//   <blockquote>
+//     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+//   </blockquote>
+// </div>
+
+blockquote {
+  border-left: 3px solid map-fetch($color, ui base);
+  padding-left: spacer(1.5);
+}


### PR DESCRIPTION
It looks like this:
![screenshot 2015-06-01 17 22 25](https://cloud.githubusercontent.com/assets/916038/7926185/874edd52-0883-11e5-96db-f068d0784d80.png)
