### PR TITLE
Remove important from the popover arrow border colors.

### DIFF
--- a/src/core/partials/elements/_mixins.scss
+++ b/src/core/partials/elements/_mixins.scss
@@ -104,11 +104,11 @@
     @extend %arrow--top;
 
     &::before {
-      border-bottom-color: $border-color !important;
+      border-bottom-color: $border-color;
     }
 
     &::after {
-      border-bottom-color: $arrow-color !important;
+      border-bottom-color: $arrow-color;
     }
 
     @if $arrow-location == left {
@@ -128,11 +128,11 @@
     @extend %arrow--far;
 
     &::before {
-      border-left-color: $border-color !important;
+      border-left-color: $border-color;
     }
 
     &::after {
-      border-left-color: $arrow-color !important;
+      border-left-color: $arrow-color;
     }
 
     @if $arrow-location == top {
@@ -152,11 +152,11 @@
     @extend %arrow--bottom;
 
     &::before {
-      border-top-color: $border-color !important;
+      border-top-color: $border-color;
     }
 
     &::after {
-      border-top-color: $arrow-color !important;
+      border-top-color: $arrow-color;
     }
 
     @if $arrow-location == left {
@@ -176,11 +176,11 @@
     @extend %arrow--near;
 
     &::before {
-      border-right-color: $border-color !important;
+      border-right-color: $border-color;
     }
 
     &::after {
-      border-right-color: $arrow-color !important;
+      border-right-color: $arrow-color;
     }
 
     @if $arrow-location == top {


### PR DESCRIPTION
@tomgenoni – Please merge if this looks good to you. I've tested it in the Optimizely app.