### PR TITLE
Add a line-height to the help object so it works better in most applications.

### DIFF
--- a/src/core/partials/objects/_help.scss
+++ b/src/core/partials/objects/_help.scss
@@ -14,6 +14,7 @@
   color: map-fetch($color, text white);
   width: 16px;
   height: 16px;
+  line-height: 16px;
   text-align: center;
   display: inline-block;
   border-radius: 50%;


### PR DESCRIPTION
@tomgenoni – Needed this to use in a part of the product where the `line-height` was `10px`.

Merge if it looks good!