### PR TITLE
refactor form label optional to not use pseudo element content

### DIFF
--- a/src/core/partials/base/_form.scss
+++ b/src/core/partials/base/_form.scss
@@ -12,7 +12,10 @@
 //     <fieldset>
 //       <ol class="lego-form-fields">
 //         <li class="lego-form-field__item">
-//           <label class="lego-label lego-label--optional">Single Input</label>
+//           <label class="lego-label">
+//             Single Input
+//             <span class="lego-label__optional">(Optional)</span>
+//           </label>
 //           <input type="text" class="lego-text-input">
 //           <div class="lego-form-note">This is a form note.</div>
 //         </li>
@@ -397,8 +400,7 @@ fieldset {
   margin-bottom: spacer(0.5);
   font-weight: 500;
 
-  &--optional::after {
-    content: '(Optional)';
+  &__optional {
     margin-left: spacer(0.5);
     color: map-fetch($color, text muted);
     font-size: map-fetch($font, size micro);


### PR DESCRIPTION
@tomgenoni This is to address this JIRA ticket for i18n: https://optimizely.atlassian.net/browse/UXD-72

There are only about a dozen places this is used in the product and I can make a PR there as well to accompany this.

Just wanted to check and see if this is an ok way to address or if you'd prefer a different approach. This is also pretty similar to the .tagger class and I'm wondering if we would want to consolidate and make something like '.deemphasized-note' (terrible name, I know..) or something along those lines.

Let me know if you have ideas around this.