### PR TITLE
Allow `.lego-overlay` to be extended with `%lego-overlay`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 - [Patch] Add a `.lego-pane--scroll-x` for setting `overflow-x` to `auto`.
 - [Patch] Add a `.pointer-events--none` trump for disabling pointer events.
 - [Patch] Add a `.cursor--move` trump for changing the cursor to `move`.
+- [Patch] Allow `.lego-overlay` to be extended with `%lego-overlay`.
 
 ### Fixed
 - [Patch] Fix the name of the npm module and changed the privacy setting to false.

--- a/src/core/partials/objects/_spinner.scss
+++ b/src/core/partials/objects/_spinner.scss
@@ -27,8 +27,8 @@
 
 // [---]
 
-.lego-overlay,
-%lego-overlay {
+%lego-overlay,
+.lego-overlay {
   @include display(flex);
   @include justify-content(center);
   @include align-items(center);

--- a/src/core/partials/objects/_spinner.scss
+++ b/src/core/partials/objects/_spinner.scss
@@ -27,7 +27,8 @@
 
 // [---]
 
-.lego-overlay {
+.lego-overlay,
+%lego-overlay {
   @include display(flex);
   @include justify-content(center);
   @include align-items(center);


### PR DESCRIPTION
@tomgenoni – Am I doing this right? The new class that extends LEGO's overlay will look like this:

```css
.info-loader-wrap {
  @extend %lego-overlay;
  @include flex-direction(column);
}
```