### PR TITLE
Rewrite `.lego-pane-empty` to use an existing mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased][unreleased]
+### Changed
+- [Patch] Rewrite `.lego-pane-empty` to use an existing mixin. (#67)
 
 ## [0.0.3][0.0.3] - 2015-08-05
 ### Added

--- a/src/core/partials/components/_layout.scss
+++ b/src/core/partials/components/_layout.scss
@@ -68,9 +68,7 @@
   }
 
   &--empty {
-    @include display(flex);
-    @include justify-content(center);
-    @include align-items(center);
+    @include flex-center;
   }
 }
 


### PR DESCRIPTION
Addresses https://github.com/optimizely/lego/issues/67.