### PR TITLE
#76 - Fix incorrect comments in _spinner.scss.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased][unreleased]
+### Fixed
+- [Patch] Change comments in `_spinner.scss` to refer to `.lego-overlay` since `.lego-spinner-wrap` doesn't exist. (#76)
 
 ## [0.0.3][0.0.3] - 2015-08-05
 ### Added

--- a/src/core/partials/objects/_spinner.scss
+++ b/src/core/partials/objects/_spinner.scss
@@ -1,16 +1,16 @@
 // ---
 // title: Spinner
-// description: Loading spinner. Target '.lego-spinner-wrap' to position as needed.
+// description: Loading spinner. Target '.lego-overlay' to position as needed.
 // ---
 
 // <div class="example html">
-//   <div class="lego-spinner-wrap">
+//   <div class="lego-overlay">
 //     <div class="lego-spinner"></div>
 //   </div>
-//   <div class="lego-spinner-wrap">
+//   <div class="lego-overlay">
 //     <div class="lego-spinner lego-spinner--small"></div>
 //   </div>
-//   <div class="lego-spinner-wrap">
+//   <div class="lego-overlay">
 //     <div class="lego-spinner lego-spinner--tiny"></div>
 //   </div>
 // </div>


### PR DESCRIPTION
Simple PR that relates to https://github.com/optimizely/lego/issues/76.