### PR TITLE
Remove concatenation from `@font-face` because it is breaking the SCSS parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 ### Changed
 - [Release] Major refactor of button styles and class names. New available class names are '.lego-button--highlight', '.lego-button--outline', '.lego-button--outline-reverse', '.lego-button--extra', '.lego-button--dismiss'. '.lego-button--brand' has been deprecated. Useage for classes to follow shortly. (#92) (#85) (#74)
 - [Release] Added `!important` to buttons so that when used as anchors the color is consistent.
+- [Patch] Removed concatenation from the `@font-face` URL strings because it was breaking the SCSS parser used for documentation generation.
 
 ## [0.0.3][0.0.3] - 2015-08-05
 ### Added

--- a/src/core/partials/base/_fonts.scss
+++ b/src/core/partials/base/_fonts.scss
@@ -32,8 +32,8 @@ $hosted-fonts:(
   @font-face {
     font-family: 'Proxima';
     font-weight: $weight;
-    src: url('#{map-fetch($hosted-fonts, url)}' + 'proximanova-#{map-fetch($hosted-fonts, weights $weight)}.woff2') format('woff2'),
-         url('#{map-fetch($hosted-fonts, url)}' + 'proximanova-#{map-fetch($hosted-fonts, weights $weight)}.woff') format('woff');
+    src: url('#{map-fetch($hosted-fonts, url)}proximanova-#{map-fetch($hosted-fonts, weights $weight)}.woff2') format('woff2'),
+         url('#{map-fetch($hosted-fonts, url)}proximanova-#{map-fetch($hosted-fonts, weights $weight)}.woff') format('woff');
   }
 
   // If italic versions should be included.
@@ -42,8 +42,8 @@ $hosted-fonts:(
       font-family: 'Proxima';
       font-weight: $weight;
       font-style: italic;
-      src: url('#{map-fetch($hosted-fonts, url)}' + 'proximanova-#{map-fetch($hosted-fonts, weights $weight)}it.woff2') format('woff2'),
-           url('#{map-fetch($hosted-fonts, url)}' + 'proximanova-#{map-fetch($hosted-fonts, weights $weight)}it.woff') format('woff');
+      src: url('#{map-fetch($hosted-fonts, url)}proximanova-#{map-fetch($hosted-fonts, weights $weight)}it.woff2') format('woff2'),
+           url('#{map-fetch($hosted-fonts, url)}proximanova-#{map-fetch($hosted-fonts, weights $weight)}it.woff') format('woff');
     }
   }
 }


### PR DESCRIPTION
@tomgenoni – I'd like to commit this to unblock the SCSS generator script. This is the only issue with the parser that I haven't been able to fix. I've filed a bug in the repository: https://github.com/tonyganch/gonzales-pe/issues/85