### PR TITLE
Clarify `CONTRIBUTING.md` to suggest only pushing the newly created tag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased][unreleased]
+### Fixed
+- [Patch] Clarify `CONTRIBUTING.md` to suggest only pushing the newly created tag. (#107)
 
 ## [3.0.0][3.0.0] - 2015-09-01
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,6 @@
 1. Open the `CHANGELOG.md` and look at the "Unreleased" contributions.
 2. `git checkout master` and run `gulp patch`, `gulp feature`, or `gulp release` depending on the highest importance issue.
 3. Update the `CHANGELOG.md` to reflect the new release and commit the change on `master`.
-4. Push the changes to `master` with `git push` and `git push --tags`.
+4. Push the changes to `master` with `git push` and `git push origin v1.2.3` where `v1.2.3` is the tag that gulp created.
 5. [Create a new release on GitHub](https://github.com/optimizely/lego/releases/new) using the version number gulp generated. Paste the "Unreleased" contributions from the `CHANGELOG.md` in the release notes.
 6. Run `npm publish ./` to push the version to NPM. You must be a LEGO contributor on NPM to do this.


### PR DESCRIPTION
@kwalker3690 – Can you review this please? 

Relates to: https://github.com/optimizely/lego/issues/107