### PR TITLE
Select height fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 - [Patch] Clarify the "Releasing a new version of LEGO" steps. (#111)
 - [Patch] Clarify `CONTRIBUTING.md` to suggest only pushing the newly created tag. (#107)
 - [Patch] Fixes alignment of `lego-icon` inside `lego-button`.
+- [Patch] Fixes height of `lego-select` by adding `box-sizing: content-box;` so height will be calculated the same as `lego-button`.
 
 ## [3.1.0][3.1.0] - 2015-09-02
 ### Added

--- a/src/core/partials/base/_form.scss
+++ b/src/core/partials/base/_form.scss
@@ -338,6 +338,7 @@
 
 .lego-select {
   @include transition(border-color map-fetch($transition-duration, base));
+  box-sizing: content-box;
   display: inline-block;
   height: map-fetch($button, size base height);
   line-height: map-fetch($button, size base height);


### PR DESCRIPTION

![screen shot 2015-09-04 at 2 48 10 pm](https://cloud.githubusercontent.com/assets/1171072/9695175/06666ba2-5314-11e5-975f-77cd379a1dde.png)
`.lego-select` was too short. This makes it behave like new buttons by calculating the same way buttons do. Any changes to `.lego-button` height will now apply correctly to `.lego-select`.