### PR TITLE
Added back a reference to the `_borders.scss` file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This file follows the format suggested by [Keep a CHANGELOG](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased][unreleased]
+### Fixed
+- [Patch] Added back a reference to the `_borders.scss` file. (#127)
 
 ## [4.0.0][4.0.0] - 2015-09-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ For example, if you're building a mobile site, `mobile.scss` would contain:
 // Trumps use `!important` classes for overrides and should always be loaded last.
 
 @import 'core/partials/trumps/background';
+@import 'core/partials/trumps/borders';
 @import 'core/partials/trumps/layout';
 @import 'core/partials/trumps/margin';
 @import 'core/partials/trumps/padding';

--- a/src/core/core.scss
+++ b/src/core/core.scss
@@ -22,6 +22,7 @@ $include-fonts:(
 // ## Trumps
 // Trumps use `!important` classes for overrides and should always be loaded last.
 @import 'partials/trumps/background';
+@import 'partials/trumps/borders';
 @import 'partials/trumps/layout';
 @import 'partials/trumps/margin';
 @import 'partials/trumps/padding';


### PR DESCRIPTION
Relates to this issue: https://github.com/optimizely/lego/issues/127

Going to immediately release this as v4.0.1 to fix broken borders in the app.