### PR TITLE
Deprecated flex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 ### Deprecated
 - [Patch] Adding `_layout--deprecated.scss` to temporarily retain the `lego-pane...` classes (#70)
 - [Patch] Adding `_sizing--deprecated.scss` to temporarily retain the `width/height-` trumps. (#69)
+- [Patch] Adding `_flexbox--deprecated.scss` to temporarily retain the `flex-` classes.
 - [Patch] Adding instructions in CONTRIBUTING.md about how to handle deprecated code.
 
 ## [4.0.0][4.0.0] - 2015-09-14

--- a/src/core/_core-partials.scss
+++ b/src/core/_core-partials.scss
@@ -7,6 +7,7 @@
 
 @import 'partials/elements/clearfix';
 @import 'partials/elements/flexbox';
+@import 'partials/elements/flexbox--deprecated';
 
 // ## Base
 // Baseline rules.

--- a/src/core/partials/elements/_flexbox--deprecated.scss
+++ b/src/core/partials/elements/_flexbox--deprecated.scss
@@ -1,0 +1,76 @@
+// # Flexbox
+// Flexbox support is full on Chrome, Firefox and Safari (with prefix) and nearly full for IE 10.
+//
+// - With IE10 at least one of the flex children needs to have a width or flex value otherwise the content in those children will not wrap. However, if none of children will collide, no width or flex value is needed.
+//
+// `flex-grow` is not supported by IE10, `justify-content` is the next best thing.
+//
+// Use in Sass with:
+//
+//[c]
+//     .foo {
+//          @include display(flex);
+//          @include flex(1);
+//     }
+//[/c]
+//
+// or the corresponding classes directly in the HTML.
+//
+//[c]
+//     <div class="flex flex-1">item</div>
+//[/c]
+
+
+// ## Flex classes
+
+.flex {
+  @include display(flex);
+}
+
+.flex-1 {
+  @include flex(1);
+}
+
+.flex-none {
+  @include flex(none);
+}
+
+.flex-wrap--wrap {
+  @include flex-wrap(wrap);
+}
+
+.flex-wrap--nowrap {
+  @include flex-wrap(nowrap);
+}
+
+.flex-direction--column {
+  @include flex-direction(column)
+}
+
+.justify-content--space-between {
+  @include justify-content(space-between);
+}
+
+.justify-content--center {
+  @include justify-content(center);
+}
+
+.justify-content--flex-start {
+  @include justify-content(flex-start);
+}
+
+.justify-content--flex-end {
+  @include justify-content(flex-end);
+}
+
+.align-items--center {
+  @include align-items(center)
+}
+
+.align-items--flex-start {
+  @include align-items(flex-start)
+}
+
+.align-items--flex-end {
+  @include align-items(flex-end)
+}


### PR DESCRIPTION
@danoc Please review. These add back the older flex classes. Note that I removed the old mixins as they were dupes of existing ones, except for the `min-height` change but that shouldn't be a problem.