### PR TITLE
Fixing height of lego select.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file follows the format suggested by [Keep a CHANGELOG](https://github.com/
 ## [Unreleased][unreleased]
 ### Fixed
 - [Patch] Added back a reference to the `_borders.scss` file. (#127)
+- [Patch] Fixes bug in previous release that caused the height of `lego-select` to be too large in FF/IE.
 
 ### Deprecated
 - [Patch] Adding `_layout--deprecated.scss` to temporarily retain the `lego-pane...` classes (#70)

--- a/src/core/partials/base/_form.scss
+++ b/src/core/partials/base/_form.scss
@@ -345,11 +345,10 @@
   box-sizing: content-box;
   display: inline-block;
   height: map-fetch($button, size base height);
-  line-height: map-fetch($button, size base height);
   background: map-fetch($color, background white);
   border: 1px solid map-fetch($color, ui base);
   border-radius: map-fetch($border-radius, base);
-  padding: 7px;
+  padding: 0 spacer(0.5);
   max-width: 100%;
 
   &:hover {


### PR DESCRIPTION
Image shows fix in Saf/Chrome/FF/IE.

<img width="1543" alt="screen shot 2015-09-22 at 10 04 39 am" src="https://cloud.githubusercontent.com/assets/1171072/10025510/83a2422a-6111-11e5-8c60-23fb0f55c61c.png">

@danoc @tscanlin 